### PR TITLE
Fix Hatchery effect not having a price

### DIFF
--- a/heavenlyUpgrades.js
+++ b/heavenlyUpgrades.js
@@ -5415,6 +5415,7 @@
                 name: 'Hatchery effect',
                 desc: 'Fish have a <b>10%</b> chance to appear in pairs.',
                 ddesc: 'Fish have a <b>10%</b> chance to appear in pairs.<q>Double the fish, double the fun!</q>',
+                price: 2500e16
                 icon: JNE.icon(2, 25, 'custom'),
                 posX: -2076,
                 posY: -1766,


### PR DESCRIPTION
This caused an issue where mods like More Heavenly Upgrades Remastered try to calculate heavenly chips by subtracting every upgrade bought from your prestige, resulting in NaN.
Change price if you need, I just set it to 25 quintillion following the exponential growth that was shown for previous upgrades.

Code snippet below from More Heavenly Upgrades Remastered
```javascript
//Readjust Heavenly Cookies on every reset
Game.customAscend.push(function realHeavenlyChips() {
    if (Game.ascensionMode === 1) return;
    let sumOfHeavenlyChips = 0;
    for (let i in Game.Upgrades) {
        if (Game.Upgrades[i].pool == 'prestige' && Game.Has(Game.Upgrades[i].name)) {
            sumOfHeavenlyChips += Game.Upgrades[i].basePrice;
        }
    }
    Game.heavenlyChips = Game.prestige - sumOfHeavenlyChips;
});
```